### PR TITLE
Add support for both ways of testing: Mock & Integration

### DIFF
--- a/api-builder-plugin-fn-redis/src/index.js
+++ b/api-builder-plugin-fn-redis/src/index.js
@@ -18,7 +18,9 @@ async function getPlugin(pluginConfig, options) {
 		return Promise.reject(ex);
 	}
 	// All you pass here will be set as context for your actions
-	return createPluginWithContext({ redisClient });
+	var plugin = createPluginWithContext({ redisClient });
+	plugin.flownodes['redis'].redisClient = redisClient;
+	return plugin;
 }
 
 module.exports = getPlugin;

--- a/api-builder-plugin-fn-redis/src/redis-client.js
+++ b/api-builder-plugin-fn-redis/src/redis-client.js
@@ -16,7 +16,7 @@ module.exports = async (pluginConfig, options) => {
 				}
 			}
 		});
-		
+
 		// Register redisClient hooks
 		redisClient.on("error", reject);
 		redisClient.on('connect', () => {
@@ -27,20 +27,22 @@ module.exports = async (pluginConfig, options) => {
 		redisClient.on('ready', () => {
 			options.logger.trace(`Redis client is ready!`);
 			return resolve(createInterface(redisClient));
-		});		
-		redisClient.on('end', function() {
+		});
+		redisClient.on('end', function () {
 			// For some reason when we overide retry strategy 'end' is emitted
 			// before `error` so just trace and don't deal with the promise here.
 			options.logger.trace(`Redis server connection closed!`);
 		});
-
-		registerRuntimeHooks({
-			stopping: () => {
-				redisClient.quit(() => {
-					options.logger.trace(`Redis client quit!`);
-				})
-			}
-		});
+		// Don't try to register runtime hooks when running tests.
+		if (!options.isTest) {
+			registerRuntimeHooks({
+				stopping: () => {
+					redisClient.quit(() => {
+						options.logger.trace(`Redis client quit!`);
+					})
+				}
+			});
+		}
 	});
 }
 
@@ -55,6 +57,7 @@ module.exports = async (pluginConfig, options) => {
 function createInterface(redisClient) {
 	return {
 		get: promisify(redisClient.get).bind(redisClient),
-		set: promisify(redisClient.set).bind(redisClient)
+		set: promisify(redisClient.set).bind(redisClient), 
+		quit: promisify(redisClient.quit).bind(redisClient)
 	}
 }

--- a/api-builder-plugin-fn-redis/test/test-config/basic-config.js
+++ b/api-builder-plugin-fn-redis/test/test-config/basic-config.js
@@ -1,6 +1,8 @@
 module.exports = {
 	pluginConfig: {
 		'@axway-api-builder-ext/api-builder-plugin-fn-redis': {
+			// When host is set to 'MOCK' all call to Redis are mocked
+			//host: 'MOCK', 
 			host: 'api-env', 
 			port: '16379'
 		}

--- a/api-builder-plugin-fn-redis/test/test-config/basic-config.js
+++ b/api-builder-plugin-fn-redis/test/test-config/basic-config.js
@@ -2,8 +2,8 @@ module.exports = {
 	pluginConfig: {
 		'@axway-api-builder-ext/api-builder-plugin-fn-redis': {
 			// When host is set to 'MOCK' all call to Redis are mocked
-			//host: 'MOCK', 
-			host: 'api-env', 
+			host: 'MOCK', 
+			//host: 'api-env', 
 			port: '16379'
 		}
 	}


### PR DESCRIPTION
I prefer to run tests (when possible) also against the real service. Especially with Redis it is very simple. 

This PR includes the option to either use pure Unit tests or run the same tests against a real Redis service. 

However, this is no fully functional.