### PR TITLE
Add ttl in milliseconds to set

### DIFF
--- a/api-builder-plugin-fn-redis/src/actions.js
+++ b/api-builder-plugin-fn-redis/src/actions.js
@@ -32,6 +32,8 @@ async function set(req, outputs, options) {
 	await ensureClient(this, options);
 	const key = req.params.key;
 	let value = req.params.value;
+	const expiremilliseconds = req.params.expiremilliseconds;
+	
 	if (!key) {
 		return outputs.error(null, { message: 'Missing required parameter: key' });
 	}
@@ -44,10 +46,14 @@ async function set(req, outputs, options) {
 	if (typeof value !== 'string' && !(value instanceof Date)) {
 		value = JSON.stringify(value);
 	}
-
+	
 	let result;
 	try {
-		result = await this.redisClient.set(key, value);
+		if (expiremilliseconds) {
+			result = await this.redisClient.set(key, value, 'PX', expiremilliseconds);
+		} else {
+			result = await this.redisClient.set(key, value);
+		}
 		return outputs.next(null, result);
 	} catch (err) {
 		return outputs.error(null, { message: err });

--- a/api-builder-plugin-fn-redis/src/flow-nodes.yml
+++ b/api-builder-plugin-fn-redis/src/flow-nodes.yml
@@ -24,6 +24,12 @@ flow-nodes:
                 - type: array
                 - type: object
                 - type: string
+          expiremilliseconds:
+            description: The time-to-live for this key in milliseconds
+            required: false
+            initialType: number
+            schema:
+              type: number
         outputs:
           next:
             name: Next


### PR DESCRIPTION
Realised that you cannot set a time-to-live when you create a new key in Redis. Redis doesn't allow global keys so you have to set the TTL while you're creating the current key. This change will allow you to set the TTL in milliseconds as you create it during the set.