### PR TITLE
Add ttl

### DIFF
--- a/api-builder-plugin-fn-redis/CHANGELOG.md
+++ b/api-builder-plugin-fn-redis/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added the ability to define the Time-to-Live on set.
 
 ## [0.0.4] 2020-05-06
 ### Added

--- a/api-builder-plugin-fn-redis/src/actions.js
+++ b/api-builder-plugin-fn-redis/src/actions.js
@@ -32,6 +32,8 @@ async function set(req, outputs, options) {
 	await ensureClient(this, options);
 	const key = req.params.key;
 	let value = req.params.value;
+	const expiremilliseconds = req.params.expiremilliseconds;
+	
 	if (!key) {
 		return outputs.error(null, { message: 'Missing required parameter: key' });
 	}
@@ -44,10 +46,14 @@ async function set(req, outputs, options) {
 	if (typeof value !== 'string' && !(value instanceof Date)) {
 		value = JSON.stringify(value);
 	}
-
+	
 	let result;
 	try {
-		result = await this.redisClient.set(key, value);
+		if (expiremilliseconds) {
+			result = await this.redisClient.set(key, value, 'PX', expiremilliseconds);
+		} else {
+			result = await this.redisClient.set(key, value);
+		}
 		return outputs.next(null, result);
 	} catch (err) {
 		return outputs.error(null, { message: err });

--- a/api-builder-plugin-fn-redis/src/flow-nodes.yml
+++ b/api-builder-plugin-fn-redis/src/flow-nodes.yml
@@ -24,6 +24,12 @@ flow-nodes:
                 - type: array
                 - type: object
                 - type: string
+          expiremilliseconds:
+            description: The time-to-live for this key in milliseconds
+            required: false
+            initialType: number
+            schema:
+              type: number
         outputs:
           next:
             name: Next

--- a/api-builder-plugin-fn-redis/test/test.js
+++ b/api-builder-plugin-fn-redis/test/test.js
@@ -199,7 +199,7 @@ describe('Redis flow-node', () => {
 
 			if (isUnitTest()) {
 				expect(mockedRedisClient.set.callCount).to.equal(1)
-				expect(mockedRedisClient.set.firstCall.args).to.deep.equal(['key123', 'value123']);
+				expect(mockedRedisClient.set.firstCall.args).to.deep.equal(['key123', 'value123', 'PX', '5000']);
 			}
 			expect(result.callCount).to.equal(1);
 			expect(result.output).to.equal('next');

--- a/api-builder-plugin-fn-redis/test/test.js
+++ b/api-builder-plugin-fn-redis/test/test.js
@@ -192,6 +192,20 @@ describe('Redis flow-node', () => {
 			expect(result.args).to.deep.equal([null, 'OK']);
 		});
 
+		it('should succeed with valid arguments key and value and a ttl', async function () {
+			const { flowNode, mockedRedisClient } = this;
+
+			let result = await flowNode.set({ key: 'key123', value: 'value123', expiremilliseconds: '5000' });
+
+			if (isUnitTest()) {
+				expect(mockedRedisClient.set.callCount).to.equal(1)
+				expect(mockedRedisClient.set.firstCall.args).to.deep.equal(['key123', 'value123']);
+			}
+			expect(result.callCount).to.equal(1);
+			expect(result.output).to.equal('next');
+			expect(result.args).to.deep.equal([null, 'OK']);
+		});
+
 		it('should succeed using a value with type: Object', async function () {
 			const { flowNode, mockedRedisClient } = this;
 

--- a/api-builder-plugin-fn-redis/test/test.js
+++ b/api-builder-plugin-fn-redis/test/test.js
@@ -195,11 +195,11 @@ describe('Redis flow-node', () => {
 		it('should succeed with valid arguments key and value and a ttl', async function () {
 			const { flowNode, mockedRedisClient } = this;
 
-			let result = await flowNode.set({ key: 'key123', value: 'value123', expiremilliseconds: '5000' });
+			let result = await flowNode.set({ key: 'key123', value: 'value123', expiremilliseconds: 5000 });
 
 			if (isUnitTest()) {
 				expect(mockedRedisClient.set.callCount).to.equal(1)
-				expect(mockedRedisClient.set.firstCall.args).to.deep.equal(['key123', 'value123', 'PX', '5000']);
+				expect(mockedRedisClient.set.firstCall.args).to.deep.equal(['key123', 'value123', 'PX', 5000]);
 			}
 			expect(result.callCount).to.equal(1);
 			expect(result.output).to.equal('next');


### PR DESCRIPTION
Realised we don't allow users to add time-to-live on creation of a Redis key. This is what Redis expects (you cannot set a global ttl). Added the ability to do this on set.