### PR TITLE
Updating the SDK to version 1.0.0 - First part

### DIFF
--- a/api-builder-plugin-fc-jira/Changelog.md
+++ b/api-builder-plugin-fc-jira/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Added better documentation / examples for the create issue method
 - improved README.md
+- Upgrade to @axway/api-builder-sdk v1.0.0
+- Test suite now using @axway/api-builder-test-utils v1.0.0
 
 ## [0.0.5] 2020-04-21
 ### Added

--- a/api-builder-plugin-fc-jira/Changelog.md
+++ b/api-builder-plugin-fc-jira/Changelog.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Added better documentation / examples for the create issue method
 - improved README.md
-- Upgrade to @axway/api-builder-sdk v1.0.0
 - Test suite now using @axway/api-builder-test-utils v1.0.0
 
 ## [0.0.5] 2020-04-21

--- a/api-builder-plugin-fc-jira/package-lock.json
+++ b/api-builder-plugin-fc-jira/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway-api-builder-ext/api-builder-plugin-fc-jira",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -86,7 +86,6 @@
       "resolved": "https://registry.npmjs.org/@axway/api-builder-oas-flow-node/-/api-builder-oas-flow-node-1.0.1.tgz",
       "integrity": "sha512-eCISe2aXXjvXNtRbVwIykj6YE5g4QI2c1Npz5UGkM6ouSx03IKgqYOmb7W11xNZfBH2PpeltC9nDIN3EDKwNEg==",
       "requires": {
-        "@axway/api-builder-sdk": "^0.2.1",
         "@axway/axsway": "^2.0.0-1",
         "@axway/requester": "4.0.5",
         "ajv": "^5.3.0",
@@ -318,13 +317,23 @@
       }
     },
     "@axway/api-builder-sdk": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@axway/api-builder-sdk/-/api-builder-sdk-0.2.1.tgz",
-      "integrity": "sha512-/vr/AEfLc4LS0zrsUNWvyPdsXN4U8+wlVKu9J+1gCsI1Z0w9eP/qgSMYlnF8ry6ywUaHz5nIOwe5coIBSe6dYA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@axway/api-builder-sdk/-/api-builder-sdk-1.0.0.tgz",
+      "integrity": "sha512-2Ya4iuQl/QUJW7DtrWMMUtcyPfVmdguXoADobwniOFo97Lor4EkR3tgbK50FWyCaB5V7+s9wppaZxPWDReyaeA==",
+      "dev": true,
       "requires": {
         "ajv": "^5.3.0",
-        "axway-flow-schema": "5.4.0",
         "js-yaml": "^3.13.1"
+      }
+    },
+    "@axway/api-builder-test-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@axway/api-builder-test-utils/-/api-builder-test-utils-1.0.0.tgz",
+      "integrity": "sha512-dKc8s0+TsKl3YIHfRFSbe/vxWN5MqPUVCKw5+g1r1HV7b8wWDHNafNX0rylM4OotMf/67u0VRh/XF5j+a6ReLA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "axway-flow-schema": "5.4.0"
       }
     },
     "@axway/axway-flow-authorization": {
@@ -1010,7 +1019,8 @@
     "axway-flow-schema": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/axway-flow-schema/-/axway-flow-schema-5.4.0.tgz",
-      "integrity": "sha512-C4DUdvj9OVZBAJIJgWK/U50vHkk7ewp+EJW1L5vQg67Uk4mT+23bavwFq1ttmq2JdnBBFWuPkmrombtjemgAMw=="
+      "integrity": "sha512-C4DUdvj9OVZBAJIJgWK/U50vHkk7ewp+EJW1L5vQg67Uk4mT+23bavwFq1ttmq2JdnBBFWuPkmrombtjemgAMw==",
+      "dev": true
     },
     "backoff": {
       "version": "2.5.0",

--- a/api-builder-plugin-fc-jira/package-lock.json
+++ b/api-builder-plugin-fc-jira/package-lock.json
@@ -86,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/@axway/api-builder-oas-flow-node/-/api-builder-oas-flow-node-1.0.1.tgz",
       "integrity": "sha512-eCISe2aXXjvXNtRbVwIykj6YE5g4QI2c1Npz5UGkM6ouSx03IKgqYOmb7W11xNZfBH2PpeltC9nDIN3EDKwNEg==",
       "requires": {
+        "@axway/api-builder-sdk": "^0.2.1",
         "@axway/axsway": "^2.0.0-1",
         "@axway/requester": "4.0.5",
         "ajv": "^5.3.0",
@@ -99,6 +100,16 @@
         "openapi-schemas": "^2.0.3"
       },
       "dependencies": {
+        "@axway/api-builder-sdk": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@axway/api-builder-sdk/-/api-builder-sdk-0.2.1.tgz",
+          "integrity": "sha512-/vr/AEfLc4LS0zrsUNWvyPdsXN4U8+wlVKu9J+1gCsI1Z0w9eP/qgSMYlnF8ry6ywUaHz5nIOwe5coIBSe6dYA==",
+          "requires": {
+            "ajv": "^5.3.0",
+            "axway-flow-schema": "5.4.0",
+            "js-yaml": "^3.13.1"
+          }
+        },
         "@axway/axsway": {
           "version": "2.0.0-1",
           "resolved": "https://registry.npmjs.org/@axway/axsway/-/axsway-2.0.0-1.tgz",
@@ -314,16 +325,6 @@
             "punycode": "^2.1.0"
           }
         }
-      }
-    },
-    "@axway/api-builder-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@axway/api-builder-sdk/-/api-builder-sdk-1.0.0.tgz",
-      "integrity": "sha512-2Ya4iuQl/QUJW7DtrWMMUtcyPfVmdguXoADobwniOFo97Lor4EkR3tgbK50FWyCaB5V7+s9wppaZxPWDReyaeA==",
-      "dev": true,
-      "requires": {
-        "ajv": "^5.3.0",
-        "js-yaml": "^3.13.1"
       }
     },
     "@axway/api-builder-test-utils": {
@@ -1019,8 +1020,7 @@
     "axway-flow-schema": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/axway-flow-schema/-/axway-flow-schema-5.4.0.tgz",
-      "integrity": "sha512-C4DUdvj9OVZBAJIJgWK/U50vHkk7ewp+EJW1L5vQg67Uk4mT+23bavwFq1ttmq2JdnBBFWuPkmrombtjemgAMw==",
-      "dev": true
+      "integrity": "sha512-C4DUdvj9OVZBAJIJgWK/U50vHkk7ewp+EJW1L5vQg67Uk4mT+23bavwFq1ttmq2JdnBBFWuPkmrombtjemgAMw=="
     },
     "backoff": {
       "version": "2.5.0",

--- a/api-builder-plugin-fc-jira/package.json
+++ b/api-builder-plugin-fc-jira/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@axway/api-builder-runtime": "^4.5.0",
-    "@axway/api-builder-sdk": "^1.0.0",
     "@axway/api-builder-test-utils": "^1.0.0",
     "chai": "^4.1.2",
     "mocha": "^6.1.4"

--- a/api-builder-plugin-fc-jira/package.json
+++ b/api-builder-plugin-fc-jira/package.json
@@ -34,7 +34,8 @@
   },
   "devDependencies": {
     "@axway/api-builder-runtime": "^4.5.0",
-    "@axway/api-builder-sdk": "^0.2.0",
+    "@axway/api-builder-sdk": "^1.0.0",
+    "@axway/api-builder-test-utils": "^1.0.0",
     "chai": "^4.1.2",
     "mocha": "^6.1.4"
   },

--- a/api-builder-plugin-fc-jira/test/test.js
+++ b/api-builder-plugin-fc-jira/test/test.js
@@ -1,43 +1,25 @@
 const { expect } = require('chai');
-const { MockRuntime } = require('@axway/api-builder-sdk');
+const { MockRuntime } = require('@axway/api-builder-test-utils');
 
 const getPlugin = require('../index');
 
-function getLogger () {
-	const logger = {
-		debug: () => {},
-		trace: () => {},
-		info: () => {},
-		warn: () => {},
-		error: () => {},
-		fatal: () => {}
-	};
-	logger.scope = () => logger;
-	return logger;
-}
-
 describe('Jira flow-node', () => {
-	let runtime;
+	let plugin;
+	let flowNode;
 	before(async () => {
-		const plugin = await getPlugin({}, {
-			logger: getLogger()
-		});
-		runtime = new MockRuntime(plugin);
+		plugin = await MockRuntime.loadPlugin(getPlugin);
+		flowNode = plugin.getFlowNode('jira-cp-connector');
 	});
-
 	describe('#constructor', () => {
 		it('should define flow-nodes', () => {
-			expect(runtime).to.exist;
-			// Ensure there's a flow-node and schemas created for each OAS document
-            expect(Object.keys(runtime.plugin.flownodes)).to.have.length(1);
-			const flownode = runtime.getFlowNode('jira-cp-connector');
-			expect(flownode).to.be.a('object');
+			expect(plugin).to.exist;
+			expect(flowNode).to.be.a('object');
 
 			// Ensure the flow-node matches the OAS document
-			expect(flownode.name).to.equal('JIRA Cloud Platform API');
-			expect(flownode.description).to.equal('JIRA 8.4.3');
-			expect(flownode.icon).to.be.a('string');
-			expect(Object.keys(flownode.methods)).to.deep.equal([                
+			expect(flowNode.name).to.equal('JIRA Cloud Platform API');
+			expect(flowNode.description).to.equal('JIRA 8.4.3');
+			expect(flowNode.icon).to.be.a('string');
+			expect(Object.keys(flowNode.methods)).to.deep.equal([                
                 'Create-Issue',
                 'Create-Issues',
                 'Issue-Get',
@@ -78,7 +60,7 @@ describe('Jira flow-node', () => {
 		});
 
 		it('should define valid flow-nodes', () => {
-			expect(runtime.validate()).to.not.throw;
+			plugin.validate();
 		});
 	});
 });

--- a/api-builder-plugin-fc-sap-lama/CHANGELOG.md
+++ b/api-builder-plugin-fc-sap-lama/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Test suite now using @axway/api-builder-test-utils v1.0.0
 
 ## [1.0.7] 2020-04-21
 ### Added

--- a/api-builder-plugin-fc-sap-lama/package-lock.json
+++ b/api-builder-plugin-fc-sap-lama/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway-api-builder-ext/api-builder-plugin-fc-sap-lama",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -124,6 +124,16 @@
         "ajv": "^5.3.0",
         "axway-flow-schema": "5.4.0",
         "js-yaml": "^3.13.1"
+      }
+    },
+    "@axway/api-builder-test-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@axway/api-builder-test-utils/-/api-builder-test-utils-1.0.0.tgz",
+      "integrity": "sha512-dKc8s0+TsKl3YIHfRFSbe/vxWN5MqPUVCKw5+g1r1HV7b8wWDHNafNX0rylM4OotMf/67u0VRh/XF5j+a6ReLA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "axway-flow-schema": "5.4.0"
       }
     },
     "@axway/axsway": {

--- a/api-builder-plugin-fc-sap-lama/package.json
+++ b/api-builder-plugin-fc-sap-lama/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@axway/api-builder-runtime": "^4.5.0",
-    "@axway/api-builder-sdk": "^0.2.0",
+    "@axway/api-builder-test-utils": "^1.0.0",
     "chai": "^4.1.2",
     "mocha": "^6.1.4"
   },

--- a/api-builder-plugin-fc-sap-lama/test/test.js
+++ b/api-builder-plugin-fc-sap-lama/test/test.js
@@ -1,43 +1,26 @@
 const { expect } = require('chai');
-const { MockRuntime } = require('@axway/api-builder-sdk');
+const { MockRuntime } = require('@axway/api-builder-test-utils');
 
 const getPlugin = require('../index');
 
-function getLogger () {
-	const logger = {
-		debug: () => {},
-		trace: () => {},
-		info: () => {},
-		warn: () => {},
-		error: () => {},
-		fatal: () => {}
-	};
-	logger.scope = () => logger;
-	return logger;
-}
-
 describe('SAP Landscape flow-node', () => {
-	let runtime;
+	let plugin;
+	let flowNode;
 	before(async () => {
-		const plugin = await getPlugin({}, {
-			logger: getLogger()
-		});
-		runtime = new MockRuntime(plugin);
+		plugin = await MockRuntime.loadPlugin(getPlugin);
+		flowNode = plugin.getFlowNode('sap-lama-api');
 	});
 
 	describe('#constructor', () => {
 		it('should define flow-nodes', () => {
-			expect(runtime).to.exist;
-			// Ensure there's a flow-node and schemas created for each OAS document
-            expect(Object.keys(runtime.plugin.flownodes)).to.have.length(1);
-			const flownode = runtime.getFlowNode('sap-lama-api');
-			expect(flownode).to.be.a('object');
+			expect(plugin).to.exist;
+			expect(flowNode).to.be.a('object');
 
 			// Ensure the flow-node matches the OAS document
-			expect(flownode.name).to.equal('SAP Landscape Mgt.');
-			expect(flownode.description).to.equal('SAP Landscape Management 3.0 API to used in the Axway API-Builder Connector.');
-			expect(flownode.icon).to.be.a('string');
-			expect(Object.keys(flownode.methods)).to.deep.equal([                
+			expect(flowNode.name).to.equal('SAP Landscape Mgt.');
+			expect(flowNode.description).to.equal('SAP Landscape Management 3.0 API to used in the Axway API-Builder Connector.');
+			expect(flowNode.icon).to.be.a('string');
+			expect(Object.keys(flowNode.methods)).to.deep.equal([                
                 'Get-XSRF-Token',
                 'Cancel-Activity',
                 'Continue-Activity',
@@ -109,7 +92,7 @@ describe('SAP Landscape flow-node', () => {
 		});
 
 		it('should define valid flow-nodes', () => {
-			expect(runtime.validate()).to.not.throw;
+			plugin.validate();
 		});
 	});
 });

--- a/api-builder-plugin-fc-syncplicity/CHANGELOG.md
+++ b/api-builder-plugin-fc-syncplicity/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Test suite now using @axway/api-builder-test-utils v1.0.0
 
 ## [1.0.1] 2020-04-21
 ### Added

--- a/api-builder-plugin-fc-syncplicity/package-lock.json
+++ b/api-builder-plugin-fc-syncplicity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway-api-builder-ext/api-builder-plugin-fc-syncplicity",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -124,6 +124,16 @@
         "ajv": "^5.3.0",
         "axway-flow-schema": "5.4.0",
         "js-yaml": "^3.13.1"
+      }
+    },
+    "@axway/api-builder-test-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@axway/api-builder-test-utils/-/api-builder-test-utils-1.0.0.tgz",
+      "integrity": "sha512-dKc8s0+TsKl3YIHfRFSbe/vxWN5MqPUVCKw5+g1r1HV7b8wWDHNafNX0rylM4OotMf/67u0VRh/XF5j+a6ReLA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "axway-flow-schema": "5.4.0"
       }
     },
     "@axway/axsway": {

--- a/api-builder-plugin-fc-syncplicity/package.json
+++ b/api-builder-plugin-fc-syncplicity/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@axway/api-builder-runtime": "^4.5.0",
-    "@axway/api-builder-sdk": "^0.2.0",
+    "@axway/api-builder-test-utils": "^1.0.0",
     "chai": "^4.1.2",
     "mocha": "^6.1.4"
   },

--- a/api-builder-plugin-fc-syncplicity/test/test.js
+++ b/api-builder-plugin-fc-syncplicity/test/test.js
@@ -1,43 +1,26 @@
 const { expect } = require('chai');
-const { MockRuntime } = require('@axway/api-builder-sdk');
+const { MockRuntime } = require('@axway/api-builder-test-utils');
 
 const getPlugin = require('../index');
 
-function getLogger () {
-	const logger = {
-		debug: () => {},
-		trace: () => {},
-		info: () => {},
-		warn: () => {},
-		error: () => {},
-		fatal: () => {}
-	};
-	logger.scope = () => logger;
-	return logger;
-}
-
 describe('Syncplicity flow-node', () => {
-	let runtime;
+	let plugin;
+	let flowNode;
 	before(async () => {
-		const plugin = await getPlugin({}, {
-			logger: getLogger()
-		});
-		runtime = new MockRuntime(plugin);
+		plugin = await MockRuntime.loadPlugin(getPlugin);
+		flowNode = plugin.getFlowNode('syncplicity');
 	});
 
 	describe('#constructor', () => {
 		it('should define flow-nodes', () => {
-			expect(runtime).to.exist;
-			// Ensure there's a flow-node and schemas created for each OAS document
-            expect(Object.keys(runtime.plugin.flownodes)).to.have.length(1);
-			const flownode = runtime.getFlowNode('syncplicity');
-			expect(flownode).to.be.a('object');
+			expect(plugin).to.exist;
+			expect(flowNode).to.be.a('object');
 
 			// Ensure the flow-node matches the OAS document
-			expect(flownode.name).to.equal('Syncplicity');
-			expect(flownode.description).to.equal('Syncplicity Connector based on API-Version 1.1');
-			expect(flownode.icon).to.be.a('string');
-			expect(Object.keys(flownode.methods)).to.deep.equal([
+			expect(flowNode.name).to.equal('Syncplicity');
+			expect(flowNode.description).to.equal('Syncplicity Connector based on API-Version 1.1');
+			expect(flowNode.icon).to.be.a('string');
+			expect(Object.keys(flowNode.methods)).to.deep.equal([
                 'Company GET',
                 'Users POST',
                 'Users PUT',
@@ -98,7 +81,7 @@ describe('Syncplicity flow-node', () => {
 		});
 
 		it('should define valid flow-nodes', () => {
-			expect(runtime.validate()).to.not.throw;
+			plugin.validate();
 		});
 	});
 });


### PR DESCRIPTION
As of now, only the OpenAPI based plugins are now updated. Basically using the new api-builder-test-utils